### PR TITLE
fix bug: new ingredient button doesn't submit form

### DIFF
--- a/src/lib/components/recipe-form/recipe-form.svelte
+++ b/src/lib/components/recipe-form/recipe-form.svelte
@@ -356,7 +356,9 @@
 									</Label>
 								</Popover.Content>
 							</Popover.Root>
-							<Button size="sm" disabled={!templateIsValid(i)} type="submit">Lisää</Button>
+							<Button size="sm" disabled={!templateIsValid(i)} onclick={(e) => handleCommit(e, i)}
+								>Lisää</Button
+							>
 						</div>
 					{/snippet}
 				</Form.Control>


### PR DESCRIPTION
Closes #54

The bug was caused by #53 which changed the ingredient template row from a form to a regular div, but left the button to be of type "submit". This caused the outer form to submit when the button was clicked.